### PR TITLE
Remove dev vcpkg install

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,14 +36,6 @@ jobs:
           with open(output_file, "a", encoding="utf-8") as output_stream:
               output_stream.write(f"count={num_cpus}\n")
 
-      - name: Install vcpkg on Windows
-        run: |
-          cd C:\
-          rm -r -fo 'C:\vcpkg'
-          git clone https://github.com/microsoft/vcpkg
-          cd vcpkg
-          .\bootstrap-vcpkg.bat
-
       - name: Build wheels on Windows
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:


### PR DESCRIPTION
Removes an outdated installation of the dev version of vcpkg

Related to https://github.com/pybamm-team/PyBaMM/issues/4632