### PR TITLE
Fix `IDACalcIC` error with time steps too close together

### DIFF
--- a/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
+++ b/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
@@ -705,7 +705,10 @@ void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitializationDAE(
   // of the initial step and its order of magnitude estimate. Add a
   // small buffer to t_next to ensure that the initialization is
   // consistent with the solver's roundoff.
-  IDACalcIC(ida_mem, icopt, 1.1 * (t_next + 1));
+  realtype tout1 = 1.01 * t_next;
+  // Support both forward and backward integration.
+  tout1 += (t_next > t_val) ? 1.0 : -1.0;
+  IDACalcIC(ida_mem, icopt, tout1);
 }
 
 template <class ExprSet>

--- a/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
+++ b/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
@@ -701,7 +701,11 @@ void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitializationDAE(
   const realtype& t_next,
   const int& icopt) {
   DEBUG("IDAKLUSolver::ConsistentInitializationDAE");
-  IDACalcIC(ida_mem, icopt, t_next);
+  // The solver requires a future time point to calculate the direction
+  // of the initial step and its order of magnitude estimate. Add a
+  // small buffer to t_next to ensure that the initialization is
+  // consistent with the solver's roundoff.
+  IDACalcIC(ida_mem, icopt, 1.1 * (t_next + 1));
 }
 
 template <class ExprSet>


### PR DESCRIPTION
Fixes the error
```python
tout1 too close to t0 to attempt initial condition calculation
```
which appears when points in `t_eval` are too close together. The value of `tout1` provides the direction of integration and the order of magnitude of the step, meaning its true value is unimportant. This PR adds a buffer to `tout1` to avoid the error.