### PR TITLE
Unpin numpy, use macos-latest, support python 3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -189,8 +189,8 @@ jobs:
             python install_KLU_Sundials.py
             python -m cibuildwheel --output-dir wheelhouse
         env:
-          # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
-          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
+          # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-latest and macos-latest)
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-latest' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
           CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate
           CIBW_REPAIR_WHEEL_COMMAND: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build and test
         run: |
           cd ..
-          git clone https://github.com/pybamm-team/PyBaMM.git
+          git clone https://github.com/agriyakhetarpal/PyBaMM.git --branch test-numpy2-and-python3.13
           # Install PyBaMM
           cd PyBaMM
           pip install -e ".[all,dev,jax]"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pybammsolvers"
 description = "Python interface for the IDAKLU solver"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 license-files = ["LICENSE"]
 dynamic = ["version", "readme"]
 dependencies = [
     "casadi==3.6.7",
-    "numpy<2.0"
+    "numpy"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This will be needed for the next release, but will have a lot of failing tests for now