### PR TITLE
Incomplete sensitivities for 1D+ output_variables 

### DIFF
--- a/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
+++ b/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
@@ -886,6 +886,7 @@ void IDAKLUSolverOpenMP<ExprSet>::SetStepOutputSensitivities(
 
       // fill sensitivities
       for (int paramk = 0; paramk < number_of_parameters; paramk++) {
+        auto &yS_back_paramk = yS[i_save][paramk];
         sunrealtype sens = dvar_dp_dense[paramk];  // Direct term
 
         for (int nz = 0; nz < dvar_dy->nnz_out(); ++nz) {
@@ -894,7 +895,7 @@ void IDAKLUSolverOpenMP<ExprSet>::SetStepOutputSensitivities(
           }
         }
 
-        yS[i_save][paramk][global_out_idx] = sens;
+        yS_back_paramk[global_out_idx] = sens;
       }
     }
   }

--- a/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
+++ b/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
@@ -873,8 +873,8 @@ void IDAKLUSolverOpenMP<ExprSet>::SetStepOutputSensitivities(
     (*dvar_dp)({&tval, y_val, functions->inputs.data()}, {&res_dvar_dp[0]});
 
     const size_t n_rows = functions->var_fcns[dvar_k]->nnz_out();  // Number of components
-    const int dvar_dy_nnz = dvar_dy->nnz_out();
-    const int dvar_dp_nnz = dvar_dp->nnz_out();
+    const size_t dvar_dy_nnz = dvar_dy->nnz_out();
+    const size_t dvar_dp_nnz = dvar_dp->nnz_out();
     const auto& dvar_dy_row = dvar_dy->get_row();
     const auto& dvar_dy_col = dvar_dy->get_col();
     const auto& dvar_dp_row = dvar_dp->get_row();
@@ -885,7 +885,7 @@ void IDAKLUSolverOpenMP<ExprSet>::SetStepOutputSensitivities(
     for (size_t row = 0; row < n_rows; ++row, ++global_out_idx) {
       // Dense dvar_row/dp_k (reset to zero)
       std::fill(dvar_dp_dense.begin(), dvar_dp_dense.end(), 0.0);
-      for (int nz = 0; nz < dvar_dp_nnz; ++nz) {
+      for (size_t nz = 0; nz < dvar_dp_nnz; ++nz) {
         if (dvar_dp_row[nz] == static_cast<int>(row)) {
           dvar_dp_dense[dvar_dp_col[nz]] = res_dvar_dp[nz];  // col = parameter idx
         }
@@ -896,7 +896,7 @@ void IDAKLUSolverOpenMP<ExprSet>::SetStepOutputSensitivities(
         auto &yS_back_paramk = yS[i_save][paramk];
         sunrealtype sens = dvar_dp_dense[paramk];  // Direct term
 
-        for (int nz = 0; nz < dvar_dy_nnz; ++nz) {
+        for (size_t nz = 0; nz < dvar_dy_nnz; ++nz) {
           if (dvar_dy_row[nz] == static_cast<int>(row)) {  // row = this component
             sens += res_dvar_dy[nz] * yS_val[paramk][dvar_dy_col[nz]];
           }


### PR DESCRIPTION
When solving with `output_variables` & sensitivities, sensitivities for variables >= 1D only ever wrote to row 0 of each variable's slice (indexing with `dvar_k` gives the variable index, not the internal row). This also had the effect of offsetting the index locations of 0D variables further down the `output_variable` list, causing their associated sensitivities to be incorrect once the sensitivity array is reshaped and passed back to python.

This fix adds an inner row loop to store the entire array for non-scalar variables.

Associated pybamm issue: [#5058](https://github.com/pybamm-team/PyBaMM/issues/5058) and PR with test for this behaviour: [#5118](https://github.com/pybamm-team/PyBaMM/pull/5118)