### PR TITLE
Fix `IDASolve` error with time steps too close together

### DIFF
--- a/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
+++ b/src/pybammsolvers/idaklu_source/IDAKLUSolverOpenMP.inl
@@ -391,6 +391,11 @@ SolutionData IDAKLUSolverOpenMP<ExprSet>::solve(
   sunrealtype t0 = t_eval.front();
   sunrealtype tf = t_eval.back();
 
+  // We need a slightly perturbed tf value to avoid roundoff errors
+  // during initialization and time stepping.
+  const bool increasing = (tf > t0);
+  sunrealtype tf_perturbed = perturb_time(tf, increasing);
+
   sunrealtype t_val = t0;
   sunrealtype t_prev = t0;
   int i_eval = 0;
@@ -447,7 +452,7 @@ SolutionData IDAKLUSolverOpenMP<ExprSet>::solve(
 
   // Progress one step. This must be done before the while loop to ensure
   // that we can run IDAGetDky at t0 for dky = 1
-  int retval = IDASolve(ida_mem, tf, &t_val, yy, yyp, IDA_ONE_STEP);
+  int retval = IDASolve(ida_mem, tf_perturbed, &t_val, yy, yyp, IDA_ONE_STEP);
 
   // Store consistent initialization
   CheckErrors(IDAGetDky(ida_mem, t0, 0, yy));
@@ -527,7 +532,7 @@ SolutionData IDAKLUSolverOpenMP<ExprSet>::solve(
     t_prev = t_val;
 
     // Progress one step
-    retval = IDASolve(ida_mem, tf, &t_val, yy, yyp, IDA_ONE_STEP);
+    retval = IDASolve(ida_mem, tf_perturbed, &t_val, yy, yyp, IDA_ONE_STEP);
   }
 
   int const length_of_final_sv_slice = save_outputs_only ? number_of_states : 0;
@@ -691,13 +696,11 @@ void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitializationDAE(
   const int& icopt) {
   DEBUG("IDAKLUSolver::ConsistentInitializationDAE");
   // The solver requires a future time point to calculate the direction
-  // of the initial step and its order of magnitude estimate. Add a
-  // small buffer to t_next to ensure that the initialization is
-  // consistent with the solver's roundoff.
-  sunrealtype tout1 = 1.01 * t_next;
-  // Support both forward and backward integration.
-  tout1 += (t_next > t_val) ? 1.0 : -1.0;
-  IDACalcIC(ida_mem, icopt, tout1);
+  // of the initial step and its order of magnitude estimate. Use a
+  // small perturbation that is consistent with the intended direction.
+  const bool increasing = (t_next > t_val);
+  sunrealtype t_next_perturbed = perturb_time(t_next, increasing);
+  IDACalcIC(ida_mem, icopt, t_next_perturbed);
 }
 
 template <class ExprSet>

--- a/src/pybammsolvers/idaklu_source/common.hpp
+++ b/src/pybammsolvers/idaklu_source/common.hpp
@@ -2,6 +2,7 @@
 #define PYBAMM_IDAKLU_COMMON_HPP
 
 #include <iostream>
+#include <limits>
 
 #include <idas/idas.h>                 /* prototypes for IDAS fcts., consts.    */
 #include <idas/idas_bbdpre.h>         /* access to IDABBDPRE preconditioner          */
@@ -103,6 +104,17 @@ std::vector<sunrealtype> makeSortedUnique(const T input_begin, const T input_end
 }
 
 std::vector<sunrealtype> makeSortedUnique(const np_array& input_np);
+
+/**
+ * @brief Apply a small perturbation to a time value to avoid roundoff errors
+ */
+inline sunrealtype perturb_time(const sunrealtype t, bool increasing) {
+  const sunrealtype eps = std::numeric_limits<sunrealtype>::epsilon();
+  const sunrealtype delta = SUNRsqrt(eps);
+  const sunrealtype sign = increasing ? SUN_RCONST(1.0) : -SUN_RCONST(1.0);
+  // Relative nudge ensures progress away from t, absolute nudge covers t == 0
+  return (SUN_RCONST(1.0) + delta) * t + delta * sign;
+}
 
 #ifdef NDEBUG
 #define DEBUG_VECTOR(vector)


### PR DESCRIPTION
Fixes the error
```python
tout1 too close to t0 to attempt initial condition calculation
```
which appears when points in `t_eval` are too close together. The value of `tout1` provides the direction of integration and the order of magnitude of the step, meaning its true value is unimportant. This PR adds a buffer to `tout1` to avoid the error.

This is the same issue as https://github.com/pybamm-team/pybammsolvers/pull/35, just with `IDASolve` instead of `IDACalcIC`. 