### PR TITLE
Fix failing Windows wheel builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           python-version: 3.12
 
+      # Pin to 2024.12.16 to avoid issues with finding SuiteSparse in manifest mode
+      # after SuiteSparse was split into subpackages in recent vcpkg releases.
       - name: Install vcpkg on Windows
         run: |
           cd C:\


### PR DESCRIPTION
The SuiteSparse port was split into its substituent packages in the `vcpkg` repodata (see https://github.com/microsoft/vcpkg/pull/41929). Since `vcpkg` versions the ports of its libraries along with itself, the only way to make `vcpkg`'s builds in `manifest`-mode reproducible is to pin to a specific version of it. From the oldest successful wheel build for PyBaMM before the `pybammsolvers` unvendoring, I've switched to `vcpkg` v2024.12.16 to fix the Windows wheels. The only difference in these Windows wheel builds after SuiteSparse and SUNDIALS were updated for Linux and macOS in #39 is that we use SUNDIALS v6.5.0 and an older port of SuiteSparse, which brings v5.8.0.

This PR should help with the contemporary PRs to build for platforms/architectures. However, I think one of the ways to ease the infrastructure burden going forward would be to migrate to the Meson build system and meson-python build backend, which should be a concerted effort to go in its own PR.

Closes #51