### PR TITLE
Drop pybind11 submodule and use it as a build-time dependency

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
@@ -47,7 +47,7 @@ jobs:
             CMAKE_GENERATOR="Visual Studio 17 2022"
             CMAKE_GENERATOR_PLATFORM=x64
           CIBW_ARCHS: AMD64
-          CIBW_BEFORE_BUILD: python -m pip install setuptools delvewheel # skip CasADi and CMake
+          CIBW_BEFORE_BUILD: python -m pip install setuptools delvewheel pybind11 # skip CasADi and CMake
           CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair --add-path C:/Windows/System32 -w {dest_dir} {wheel}
           CIBW_TEST_EXTRAS: "dev"
           CIBW_TEST_COMMAND: |
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
 
       - uses: actions/setup-python@v5
         with:
@@ -78,7 +78,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install openblas-devel lapack-devel &&
             python install_KLU_Sundials.py
-          CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake casadi==3.6.7 setuptools wheel
+          CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake casadi==3.6.7 setuptools wheel pybind11
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair -w {dest_dir} {wheel}
           CIBW_TEST_EXTRAS: "dev"
           CIBW_TEST_COMMAND: |
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
@@ -202,7 +202,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate pybind11
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,12 +23,7 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies (MacOs)
+      - name: Install dependencies (macOS)
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -39,6 +34,11 @@ jobs:
           brew install libomp
           brew reinstall gcc
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Build and test
         run: |
           cd ..
@@ -46,13 +46,13 @@ jobs:
           # Install PyBaMM
           cd PyBaMM
           pip install -e ".[all,dev,jax]"
-          
+
           # Replace PyBaMM solvers
           cd ../pybammsolvers
           pip uninstall pybammsolvers --yes
           python install_KLU_Sundials.py
           pip install .
-          
+
           # Run pybamm tests
           cd ../PyBaMM
           pytest tests/unit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,16 +23,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install gfortran gcc libopenblas-dev
-          pip install nox
+        run: sudo apt-get install gfortran gcc libopenblas-dev
 
       - name: Install dependencies (MacOs)
         if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
@@ -45,6 +38,14 @@ jobs:
           brew analytics off
           brew install libomp
           brew reinstall gcc
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install nox
+        run: |
           pip install nox
 
       - name: Build and test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: 'recursive'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "pybind11"]
-	path = pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "sundials"]
 	path = sundials
 	url = git@github.com:LLNL/sundials.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
-set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
-if (NOT PYBIND11_DIR)
-    set(PYBIND11_DIR pybind11)
-endif ()
-add_subdirectory(${PYBIND11_DIR})
+find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
 if (NOT DEFINED PYBAMM_IDAKLU_EXPR_CASADI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if (DEFINED Python_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif ()
+
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -32,7 +36,6 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
-set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
@@ -103,7 +106,7 @@ if (CASADI_DIR)
     file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
     message("Found Python casadi path: ${CASADI_DIR}")
 else ()
-    message(FATAL_ERROR "Did not find casadi path")
+    message(FATAL_ERROR "Did not find casadi path}")
 endif ()
 
 if (${USE_PYTHON_CASADI})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-if (DEFINED Python_EXECUTABLE)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif ()
-
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -36,6 +32,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
@@ -106,7 +103,7 @@ if (CASADI_DIR)
     file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
     message("Found Python casadi path: ${CASADI_DIR}")
 else ()
-    message(FATAL_ERROR "Did not find casadi path}")
+    message(FATAL_ERROR "Did not find casadi path")
 endif ()
 
 if (${USE_PYTHON_CASADI})

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mac dependencies can be installed using brew
 ```bash
 brew install libomp
 brew reinstall gcc
-git submodule update --init --recurisive
+git submodule update --init --recursive
 python install_KLU_Sundials.py
 pip install .
 ```
@@ -43,7 +43,7 @@ Linux installs may vary based on the distribution, however, the basic build can
 be performed with the following commands:
 ```bash
 sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
-git submodules update --init --recurisive
+git submodules update --init --recursive
 pip install cmake casadi setuptools wheel pybind11
 python install_KLU_Sundials.py
 pip install .

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ be performed with the following commands:
 ```bash
 sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
 git submodules update --init --recursive
-pip install cmake casadi setuptools wheel pybind11
+pip install cmake casadi setuptools wheel "pybind11[global]"
 python install_KLU_Sundials.py
 pip install .
 ```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Linux installs may vary based on the distribution, however, the basic build can
 be performed with the following commands:
 ```bash
 sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
-pip install cmake casadi setuptools wheel
 git submodules update --init --recurisive
+pip install cmake casadi setuptools wheel pybind11
 python install_KLU_Sundials.py
 pip install .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     # cross platforms, so updates to its minimum version here should be accompanied
     # by a version bump in https://github.com/pybamm-team/casadi-vcpkg-registry.
     "cmake; platform_system!='Windows'",
+    "pybind11>=3.0.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # cross platforms, so updates to its minimum version here should be accompanied
     # by a version bump in https://github.com/pybamm-team/casadi-vcpkg-registry.
     "cmake; platform_system!='Windows'",
-    "pybind11>=3.0.1",
+    "pybind11[global]>=3.0.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.bdist_wheel import bdist_wheel
 
+from pybind11 import get_include as pybind11_get_include
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 default_lib_dir = (
@@ -267,6 +268,7 @@ ext_modules = [
             "src/pybammsolvers/idaklu_source/Options.cpp",
             "src/pybammsolvers/idaklu.cpp",
         ],
+        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11_get_include()],
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from multiprocessing import cpu_count
 from pathlib import Path
 from platform import system
 
-from setuptools import setup, Extension
+from setuptools import setup
 from setuptools.command.install import install
-from setuptools.command.build_ext import build_ext
 from setuptools.command.bdist_wheel import bdist_wheel
 
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 default_lib_dir = (
     "" if system() == "Windows" else str(Path(__file__).parent.resolve() / ".idaklu")
@@ -231,7 +231,7 @@ class PyBaMMWheel(bdist_wheel):
 
 
 ext_modules = [
-    Extension(
+    Pybind11Extension(
         name="pybammsolvers.idaklu",
         # The sources list should mirror the list in CMakeLists.txt
         sources=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.bdist_wheel import bdist_wheel
 
-from pybind11 import get_include as pybind11_get_include
+import pybind11
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 default_lib_dir = (
@@ -93,11 +93,15 @@ class CMakeBuild(build_ext):
 
         build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "Release")
         idaklu_expr_casadi = os.getenv("PYBAMM_IDAKLU_EXPR_CASADI", "ON")
+
+        pybind11_cmake_dir = pybind11.get_cmake_dir()
+
         cmake_args = [
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DUSE_PYTHON_CASADI={}".format("TRUE" if use_python_casadi else "FALSE"),
             f"-DPYBAMM_IDAKLU_EXPR_CASADI={idaklu_expr_casadi}",
+            f"-Dpybind11_DIR={pybind11_cmake_dir}",
         ]
         if self.suitesparse_root:
             cmake_args.append(
@@ -268,7 +272,7 @@ ext_modules = [
             "src/pybammsolvers/idaklu_source/Options.cpp",
             "src/pybammsolvers/idaklu.cpp",
         ],
-        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11_get_include()],
+        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11.get_include()],
     )
 ]
 


### PR DESCRIPTION
While both pathways are fine, we may find it easier to use the `pybind11` Python package instead of using it as a submodule.

This ports one of my older PRs; pybamm-team/PyBaMM#3560 – which was stalled due to other reasons when the IDAKLU solver was considered an optional requirement.