### PR TITLE
Rework CasADi libs detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
-set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if (DEFINED Python_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif ()
+
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -32,7 +36,6 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
-set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
@@ -103,7 +106,7 @@ if (CASADI_DIR)
     file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
     message("Found Python casadi path: ${CASADI_DIR}")
 else ()
-    message(FATAL_ERROR "Did not find casadi path")
+    message(FATAL_ERROR "Did not find casadi path}")
 endif ()
 
 if (${USE_PYTHON_CASADI})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-if (DEFINED Python_EXECUTABLE)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif ()
-
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -36,6 +32,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
@@ -106,7 +103,7 @@ if (CASADI_DIR)
     file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
     message("Found Python casadi path: ${CASADI_DIR}")
 else ()
-    message(FATAL_ERROR "Did not find casadi path}")
+    message(FATAL_ERROR "Did not find casadi path")
 endif ()
 
 if (${USE_PYTHON_CASADI})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,14 @@ if (${USE_PYTHON_CASADI})
                 INSTALL_RPATH "${CASADI_LIB_DIR}"
                 INSTALL_RPATH_USE_LINK_PATH TRUE
         )
+        # Attempt to link the casadi library directly if found
+        find_library(CASADI_LIBRARY NAMES casadi PATHS ${CASADI_LIB_DIR} NO_DEFAULT_PATH)
+        if (CASADI_LIBRARY)
+            message("Found CasADi library: ${CASADI_LIBRARY}")
+            target_link_libraries(idaklu PRIVATE ${CASADI_LIBRARY})
+        else ()
+            message(WARNING "CasADi library not found in ${CASADI_LIB_DIR}. The target will rely on transitive linkage via CMake config if available.")
+        endif ()
     else ()
         message(FATAL_ERROR "Could not find CasADi library directory")
     endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-if (DEFINED Python_EXECUTABLE)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif ()
-
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -95,34 +91,60 @@ if (NOT DEFINED USE_PYTHON_CASADI)
     set(USE_PYTHON_CASADI TRUE)
 endif ()
 
-
-execute_process(
-        COMMAND "${PYTHON_EXECUTABLE}" -c
-        "import os; import sysconfig; print(os.path.join(sysconfig.get_path('purelib'), 'casadi', 'cmake'))"
-        OUTPUT_VARIABLE CASADI_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-if (CASADI_DIR)
-    file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
-    message("Found Python casadi path: ${CASADI_DIR}")
-else ()
-    message(FATAL_ERROR "Did not find casadi path}")
-endif ()
-
 if (${USE_PYTHON_CASADI})
+    execute_process(
+            COMMAND "${PYTHON_EXECUTABLE}" -c
+            "import os; import sysconfig; print(os.path.join(sysconfig.get_path('purelib'), 'casadi', 'cmake'))"
+            OUTPUT_VARIABLE CASADI_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if (CASADI_DIR)
+        file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
+        message("Found Python casadi path: ${CASADI_DIR}")
+    else ()
+        message(FATAL_ERROR "Did not find casadi path")
+    endif ()
+
     message("Trying to link against Python casadi package in ${CASADI_DIR}")
     find_package(casadi CONFIG PATHS ${CASADI_DIR} REQUIRED NO_DEFAULT_PATH)
+
+    execute_process(
+            COMMAND "${PYTHON_EXECUTABLE}" -c
+            "import casadi; from pathlib import Path; print(Path(casadi.__file__).parent / 'include')"
+            OUTPUT_VARIABLE CASADI_INCLUDE_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if (CASADI_INCLUDE_DIR)
+        file(TO_CMAKE_PATH ${CASADI_INCLUDE_DIR} CASADI_INCLUDE_DIR)
+        message("Found Python CasADi include directory: ${CASADI_INCLUDE_DIR}")
+        target_include_directories(idaklu PRIVATE ${CASADI_INCLUDE_DIR})
+    else ()
+        message(FATAL_ERROR "Could not find CasADi include directory")
+    endif ()
+
+    execute_process(
+            COMMAND "${PYTHON_EXECUTABLE}" -c
+            "import casadi; from pathlib import Path; import glob; lib_dir = Path(casadi.__file__).parent; lib_files = list(lib_dir.glob('*casadi*')); print(str(lib_dir) if lib_files else '')"
+            OUTPUT_VARIABLE CASADI_LIB_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if (CASADI_LIB_DIR)
+        file(TO_CMAKE_PATH ${CASADI_LIB_DIR} CASADI_LIB_DIR)
+        message("Found Python CasADi library directory: ${CASADI_LIB_DIR}")
+        target_link_directories(idaklu PRIVATE ${CASADI_LIB_DIR})
+
+        set_target_properties(
+                idaklu PROPERTIES
+                INSTALL_RPATH "${CASADI_LIB_DIR}"
+                INSTALL_RPATH_USE_LINK_PATH TRUE
+        )
+    else ()
+        message(FATAL_ERROR "Could not find CasADi library directory")
+    endif ()
 else ()
     message("Trying to link against any casadi package apart from the Python one")
-    set(CMAKE_IGNORE_PATH "${CASADI_DIR}/cmake")
     find_package(casadi CONFIG REQUIRED)
 endif ()
-
-set_target_properties(
-        idaklu PROPERTIES
-        INSTALL_RPATH "${CASADI_DIR}"
-        INSTALL_RPATH_USE_LINK_PATH TRUE
-)
 
 # openmp
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,11 @@ if (${USE_PYTHON_CASADI})
     endif ()
 
     message("Trying to link against Python casadi package in ${CASADI_DIR}")
-    find_package(casadi CONFIG PATHS ${CASADI_DIR} REQUIRED NO_DEFAULT_PATH)
+    if (EXISTS "${CASADI_DIR}/casadiConfig.cmake" OR EXISTS "${CASADI_DIR}/casadi-config.cmake")
+        find_package(casadi CONFIG PATHS ${CASADI_DIR} NO_DEFAULT_PATH)
+    else ()
+        message(WARNING "CasADi CMake config not found in ${CASADI_DIR}. Proceeding without find_package; using include and library paths discovered from the Python package.")
+    endif ()
 
     execute_process(
             COMMAND "${PYTHON_EXECUTABLE}" -c

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Linux installs may vary based on the distribution, however, the basic build can
 be performed with the following commands:
 ```bash
 sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
-git submodules update --init --recurisive
+git submodules update --init --recursive
 pip install cmake casadi setuptools wheel pybind11
 python install_KLU_Sundials.py
 pip install .

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ pip install .
 Linux installs may vary based on the distribution, however, the basic build can
 be performed with the following commands:
 ```bash
-sudo apt-get install libopenblas-dev gcc make g++ build-essential
-git submodules update --init --recursive
-pip install cmake casadi setuptools wheel "pybind11[global]"
+sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
+git submodules update --init --recurisive
+pip install cmake casadi setuptools wheel pybind11
 python install_KLU_Sundials.py
 pip install .
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ be performed with the following commands:
 ```bash
 sudo apt-get install libopenblas-dev gcc gfortran make g++ build-essential
 git submodules update --init --recursive
-pip install cmake casadi setuptools wheel pybind11
+pip install cmake casadi setuptools wheel "pybind11[global]"
 python install_KLU_Sundials.py
 pip install .
 ```

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.bdist_wheel import bdist_wheel
 
-from pybind11 import get_include as pybind11_get_include
+import pybind11
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 default_lib_dir = (
@@ -272,7 +272,7 @@ ext_modules = [
             "src/pybammsolvers/idaklu_source/Options.cpp",
             "src/pybammsolvers/idaklu.cpp",
         ],
-        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11_get_include()],
+        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11.get_include()],
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.bdist_wheel import bdist_wheel
 
-import pybind11
+from pybind11 import get_include as pybind11_get_include
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 default_lib_dir = (
@@ -272,7 +272,7 @@ ext_modules = [
             "src/pybammsolvers/idaklu_source/Options.cpp",
             "src/pybammsolvers/idaklu.cpp",
         ],
-        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11.get_include()],
+        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11_get_include()],
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,15 @@ def set_vcpkg_environment_variables():
 
 # ---------- find Python CasADi's include dirs (for Linux and macOS) -------------------
 
+
 def get_casadi_python_include_dir():
     import casadi
+
     casadi_path = Path(casadi.__file__).parent
     include_dir = casadi_path / "include"
     assert include_dir.exists(), f"CasADi include directory not found at {include_dir}"
     return str(include_dir)
+
 
 if USE_PYTHON_CASADI:
     casadi_include = get_casadi_python_include_dir()


### PR DESCRIPTION
I had some trouble locally working with a virtual environment where I wasn't able to find some of CasADi's headers that are required by the IDAKLU solver, causing the compilation to fail. This does not occur in CI; I have not been able to find a reason to explain this. Hence, PR reworks how we detect CasADi ever so slightly, so that we explicitly provide CasADi's `target_include_directories` and `target_link_directories` to the target, and we define `CASADI_INCLUDE_DIR` from `setup.py` to pass into CMake.