### PR TITLE
Fix CasADi in config mode, and use `pybind11`'s `FindPython` mode

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -168,7 +168,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate "pybind11[global]"
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -168,7 +168,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate "pybind11[global]"
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -168,7 +168,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate "pybind11[global]"
+          CIBW_BEFORE_BUILD: python -m pip install cmake "casadi==3.6.7" setuptools delocate "pybind11[global]"
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -103,9 +103,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
 
       - name: Install Fortran compiler
         env:
@@ -118,12 +115,10 @@ jobs:
           brew install libomp
           brew reinstall gcc
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
-
       - name: Build wheels on macOS
-        shell: bash
-        run: |
+        uses: pypa/cibuildwheel@v3.1.4
+        env:
+          CIBW_BEFORE_BUILD: |
             set -e -x
 
             # Set LLVM-OpenMP URL
@@ -159,16 +154,11 @@ jobs:
             export CXXFLAGS="$CXXFLAGS -I$PREFIX/include"
             export LDFLAGS="$LDFLAGS -L$PREFIX/lib -lomp"
 
-            # cibuildwheel not recognising its environment variable, so set manually
-            export CIBUILDWHEEL="1"
-
             python install_KLU_Sundials.py
-            python -m cibuildwheel --output-dir wheelhouse
-        env:
+            python -m pip install cmake "casadi==3.6.7" setuptools delocate "pybind11[global]"
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake "casadi==3.6.7" setuptools delocate "pybind11[global]"
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,7 +47,7 @@ jobs:
             CMAKE_GENERATOR="Visual Studio 17 2022"
             CMAKE_GENERATOR_PLATFORM=x64
           CIBW_ARCHS: AMD64
-          CIBW_BEFORE_BUILD: python -m pip install setuptools delvewheel pybind11 # skip CasADi and CMake
+          CIBW_BEFORE_BUILD: python -m pip install setuptools delvewheel "pybind11[global]" # skip CasADi and CMake
           CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair --add-path C:/Windows/System32 -w {dest_dir} {wheel}
           CIBW_TEST_EXTRAS: "dev"
           CIBW_TEST_COMMAND: |
@@ -78,7 +78,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install openblas-devel lapack-devel &&
             python install_KLU_Sundials.py
-          CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake casadi==3.6.7 setuptools wheel pybind11
+          CIBW_BEFORE_BUILD_LINUX: python -m pip install cmake casadi==3.6.7 setuptools wheel "pybind11[global]"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair -w {dest_dir} {wheel}
           CIBW_TEST_EXTRAS: "dev"
           CIBW_TEST_COMMAND: |
@@ -168,7 +168,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate pybind11
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate "pybind11[global]"
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CIBW_BUILD_VERBOSITY: 2
-  CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+  CIBW_BUILD_FRONTEND: "build; args: --no-isolation"
   # Skip PyPy and MUSL builds in any and all jobs
   CIBW_SKIP: "pp* *musllinux*"
   FORCE_COLOR: 3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
-cmake_minimum_required(VERSION 3.13)
-cmake_policy(SET CMP0074 NEW)
-set(CMAKE_VERBOSE_MAKEFILE ON)
+cmake_minimum_required(VERSION 3.26)
 
-if (DEFINED Python_EXECUTABLE)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif ()
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
@@ -36,6 +32,7 @@ endif ()
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 # Check Casadi build flag
@@ -97,7 +94,7 @@ endif ()
 
 
 execute_process(
-        COMMAND "${PYTHON_EXECUTABLE}" -c
+        COMMAND "${Python_EXECUTABLE}" -c
         "import pathlib, casadi; print(pathlib.Path(next(iter(casadi.__path__))).joinpath('cmake'))"
         OUTPUT_VARIABLE CASADI_DIR
         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.13)
 cmake_policy(SET CMP0074 NEW)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if (DEFINED Python_EXECUTABLE)
+    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif ()
+
 if (DEFINED ENV{VCPKG_ROOT_DIR} AND NOT DEFINED VCPKG_ROOT_DIR)
     set(VCPKG_ROOT_DIR "$ENV{VCPKG_ROOT_DIR}"
             CACHE STRING "Vcpkg root directory")
@@ -91,72 +95,34 @@ if (NOT DEFINED USE_PYTHON_CASADI)
     set(USE_PYTHON_CASADI TRUE)
 endif ()
 
+
+execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" -c
+        "import pathlib, casadi; print(pathlib.Path(next(iter(casadi.__path__))).joinpath('cmake'))"
+        OUTPUT_VARIABLE CASADI_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if (CASADI_DIR)
+    file(TO_CMAKE_PATH "${CASADI_DIR}" CASADI_DIR)
+    message("Found Python casadi path: ${CASADI_DIR}")
+else ()
+    message(FATAL_ERROR "Did not find casadi path")
+endif ()
+
 if (${USE_PYTHON_CASADI})
-    execute_process(
-            COMMAND "${PYTHON_EXECUTABLE}" -c
-            "import os; import sysconfig; print(os.path.join(sysconfig.get_path('purelib'), 'casadi', 'cmake'))"
-            OUTPUT_VARIABLE CASADI_DIR
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    if (CASADI_DIR)
-        file(TO_CMAKE_PATH ${CASADI_DIR} CASADI_DIR)
-        message("Found Python casadi path: ${CASADI_DIR}")
-    else ()
-        message(FATAL_ERROR "Did not find casadi path")
-    endif ()
-
     message("Trying to link against Python casadi package in ${CASADI_DIR}")
-    if (EXISTS "${CASADI_DIR}/casadiConfig.cmake" OR EXISTS "${CASADI_DIR}/casadi-config.cmake")
-        find_package(casadi CONFIG PATHS ${CASADI_DIR} NO_DEFAULT_PATH)
-    else ()
-        message(WARNING "CasADi CMake config not found in ${CASADI_DIR}. Proceeding without find_package; using include and library paths discovered from the Python package.")
-    endif ()
-
-    execute_process(
-            COMMAND "${PYTHON_EXECUTABLE}" -c
-            "import casadi; from pathlib import Path; print(Path(casadi.__file__).parent / 'include')"
-            OUTPUT_VARIABLE CASADI_INCLUDE_DIR
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    if (CASADI_INCLUDE_DIR)
-        file(TO_CMAKE_PATH ${CASADI_INCLUDE_DIR} CASADI_INCLUDE_DIR)
-        message("Found Python CasADi include directory: ${CASADI_INCLUDE_DIR}")
-        target_include_directories(idaklu PRIVATE ${CASADI_INCLUDE_DIR})
-    else ()
-        message(FATAL_ERROR "Could not find CasADi include directory")
-    endif ()
-
-    execute_process(
-            COMMAND "${PYTHON_EXECUTABLE}" -c
-            "import casadi; from pathlib import Path; import glob; lib_dir = Path(casadi.__file__).parent; lib_files = list(lib_dir.glob('*casadi*')); print(str(lib_dir) if lib_files else '')"
-            OUTPUT_VARIABLE CASADI_LIB_DIR
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    if (CASADI_LIB_DIR)
-        file(TO_CMAKE_PATH ${CASADI_LIB_DIR} CASADI_LIB_DIR)
-        message("Found Python CasADi library directory: ${CASADI_LIB_DIR}")
-        target_link_directories(idaklu PRIVATE ${CASADI_LIB_DIR})
-
-        set_target_properties(
-                idaklu PROPERTIES
-                INSTALL_RPATH "${CASADI_LIB_DIR}"
-                INSTALL_RPATH_USE_LINK_PATH TRUE
-        )
-        # Attempt to link the casadi library directly if found
-        find_library(CASADI_LIBRARY NAMES casadi PATHS ${CASADI_LIB_DIR} NO_DEFAULT_PATH)
-        if (CASADI_LIBRARY)
-            message("Found CasADi library: ${CASADI_LIBRARY}")
-            target_link_libraries(idaklu PRIVATE ${CASADI_LIBRARY})
-        else ()
-            message(WARNING "CasADi library not found in ${CASADI_LIB_DIR}. The target will rely on transitive linkage via CMake config if available.")
-        endif ()
-    else ()
-        message(FATAL_ERROR "Could not find CasADi library directory")
-    endif ()
+    find_package(casadi CONFIG PATHS "${CASADI_DIR}" REQUIRED NO_DEFAULT_PATH)
 else ()
     message("Trying to link against any casadi package apart from the Python one")
+    set(CMAKE_IGNORE_PATH "${CASADI_DIR}/cmake")
     find_package(casadi CONFIG REQUIRED)
 endif ()
+
+set_target_properties(
+        idaklu PROPERTIES
+        INSTALL_RPATH "${CASADI_DIR}"
+        INSTALL_RPATH_USE_LINK_PATH TRUE
+)
 
 # openmp
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ def run_pybamm_requires(session):
 @nox.session(name="unit")
 def run_unit(session):
     set_environment_variables(PYBAMM_ENV, session=session)
-    session.install("setuptools", silent=False)
-    session.install("casadi==3.6.7", silent=False)
-    session.install(".[dev]", silent=False)
+    build_deps = nox.project.load_toml("pyproject.toml")["build-system"]["requires"]
+    session.install(*build_deps)
+    session.install("-e", ".[dev]", "--no-build-isolation", silent=False)
     session.run("pytest", "tests")

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,6 @@ default_lib_dir = (
     "" if system() == "Windows" else str(Path(__file__).parent.resolve() / ".idaklu")
 )
 
-INCLUDE_DIRS = [str(Path(default_lib_dir) / "include"), pybind11.get_include()]
-
-USE_PYTHON_CASADI = False if system() == "Windows" else True
-
 # ---------- set environment variables for vcpkg on Windows ----------------------------
 
 
@@ -36,23 +32,6 @@ def set_vcpkg_environment_variables():
         os.getenv("VCPKG_FEATURE_FLAGS"),
     )
 
-
-# ---------- find Python CasADi's include dirs (for Linux and macOS) -------------------
-
-
-def get_casadi_python_include_dir():
-    import casadi
-
-    casadi_path = Path(casadi.__file__).parent
-    include_dir = casadi_path / "include"
-    assert include_dir.exists(), f"CasADi include directory not found at {include_dir}"
-    return str(include_dir)
-
-
-if USE_PYTHON_CASADI:
-    casadi_include = get_casadi_python_include_dir()
-    INCLUDE_DIRS.append(casadi_include)
-    print(f"Adding CasADi include directory: {casadi_include}")
 
 # ---------- CMakeBuild class (custom build_ext for IDAKLU target) ---------------------
 
@@ -107,6 +86,11 @@ class CMakeBuild(build_ext):
         # Build in parallel wherever possible
         os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str(cpu_count())
 
+        if system() == "Windows":
+            use_python_casadi = False
+        else:
+            use_python_casadi = True
+
         build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "Release")
         idaklu_expr_casadi = os.getenv("PYBAMM_IDAKLU_EXPR_CASADI", "ON")
 
@@ -115,7 +99,7 @@ class CMakeBuild(build_ext):
         cmake_args = [
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
-            "-DUSE_PYTHON_CASADI={}".format("TRUE" if USE_PYTHON_CASADI else "FALSE"),
+            "-DUSE_PYTHON_CASADI={}".format("TRUE" if use_python_casadi else "FALSE"),
             f"-DPYBAMM_IDAKLU_EXPR_CASADI={idaklu_expr_casadi}",
             f"-Dpybind11_DIR={pybind11_cmake_dir}",
         ]
@@ -125,11 +109,6 @@ class CMakeBuild(build_ext):
             )
         if self.sundials_root:
             cmake_args.append(f"-DSUNDIALS_ROOT={os.path.abspath(self.sundials_root)}")
-
-        if USE_PYTHON_CASADI:
-            casadi_include = get_casadi_python_include_dir()
-            cmake_args.append(f"-DCASADI_INCLUDE_DIR={casadi_include}")
-            print(f"Adding CasADi include directory to CMake: {casadi_include}")
 
         build_dir = self.get_build_directory()
         if not os.path.exists(build_dir):
@@ -293,7 +272,7 @@ ext_modules = [
             "src/pybammsolvers/idaklu_source/Options.cpp",
             "src/pybammsolvers/idaklu.cpp",
         ],
-        include_dirs=INCLUDE_DIRS,
+        include_dirs=[str(Path(default_lib_dir) / "include"), pybind11.get_include()],
     )
 ]
 


### PR DESCRIPTION
Building up on and partially reverting the changes in #61; I was able to figure out the problem CMake was having with the builds for CasADi in `config` mode, and this PR cuts down on a lot of unnecessary configuration. Comments below annotate the reasoning for changes.