### PR TITLE
Use `macos-15-intel` images to build macOS Intel wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-15-intel, macos-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v5
@@ -165,7 +165,7 @@ jobs:
             python install_KLU_Sundials.py
             python -m cibuildwheel --output-dir wheelhouse
         env:
-          # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-latest)
+          # 10.13 for Intel (macos-15-intel), 11.0 for Apple Silicon (macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-latest' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
           CIBW_BEFORE_BUILD: python -m pip install cmake casadi==3.6.7 setuptools delocate pybind11

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get install gfortran gcc libopenblas-dev
 
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-15-intel' || matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ for more context. We can evaluate whether to publish macOS Intel wheels anymore or not at a later time (as this affects PyBaMM users rather than direct pybammsolvers users), but at the moment this PR switches to the newer category so that we can continue to have support.