### PR TITLE
Deep-copy CasADi functions to prevent thread-unsafe shared state

### DIFF
--- a/src/pybammsolvers/idaklu.cpp
+++ b/src/pybammsolvers/idaklu.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <iostream>
 #include <functional>
+#include <optional>
 
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>
@@ -25,6 +26,98 @@ casadi::Function generate_casadi_function(const std::string &data)
 
 namespace py = pybind11;
 
+IDAKLUSolverGroup *create_casadi_solver_group(
+  int number_of_states,
+  int number_of_parameters,
+  const CasadiFunctions::BaseFunctionType &rhs_alg,
+  const CasadiFunctions::BaseFunctionType &jac_times_cjmass,
+  const np_array_int &jac_times_cjmass_colptrs,
+  const np_array_int &jac_times_cjmass_rowvals,
+  const int jac_times_cjmass_nnz,
+  const int jac_bandwidth_lower,
+  const int jac_bandwidth_upper,
+  const CasadiFunctions::BaseFunctionType &jac_action,
+  const CasadiFunctions::BaseFunctionType &mass_action,
+  const CasadiFunctions::BaseFunctionType &sens,
+  const CasadiFunctions::BaseFunctionType &events,
+  const int number_of_events,
+  np_array rhs_alg_id,
+  np_array atol_np,
+  double rel_tol,
+  int inputs_length,
+  const std::vector<CasadiFunctions::BaseFunctionType*>& var_fcns,
+  const std::vector<CasadiFunctions::BaseFunctionType*>& dvar_dy_fcns,
+  const std::vector<CasadiFunctions::BaseFunctionType*>& dvar_dp_fcns,
+  py::dict py_opts)
+{
+  auto setup_opts = SetupOptions(py_opts);
+  auto solver_opts = SolverOptions(py_opts);
+
+  std::optional<SerializedCasadiFunctions> serialized_fcns;
+  if (setup_opts.num_solvers > 1) {
+    serialized_fcns = serialize_casadi_functions(
+      rhs_alg,
+      jac_times_cjmass,
+      jac_action,
+      mass_action,
+      sens,
+      events,
+      var_fcns,
+      dvar_dy_fcns,
+      dvar_dp_fcns);
+  }
+
+  std::vector<std::unique_ptr<IDAKLUSolver>> solvers;
+  solvers.reserve(setup_opts.num_solvers);
+  for (int i = 0; i < setup_opts.num_solvers; i++) {
+    auto functions = std::make_unique<CasadiFunctions>(
+      rhs_alg,
+      jac_times_cjmass,
+      jac_times_cjmass_nnz,
+      jac_bandwidth_lower,
+      jac_bandwidth_upper,
+      jac_times_cjmass_rowvals,
+      jac_times_cjmass_colptrs,
+      inputs_length,
+      jac_action,
+      mass_action,
+      sens,
+      events,
+      number_of_states,
+      number_of_events,
+      number_of_parameters,
+      var_fcns,
+      dvar_dy_fcns,
+      dvar_dp_fcns,
+      setup_opts,
+      serialized_fcns ? &*serialized_fcns : nullptr
+    );
+    solvers.emplace_back(
+      std::unique_ptr<IDAKLUSolver>(
+        create_idaklu_solver(
+          std::move(functions),
+          number_of_parameters,
+          jac_times_cjmass_colptrs,
+          jac_times_cjmass_rowvals,
+          jac_times_cjmass_nnz,
+          jac_bandwidth_lower,
+          jac_bandwidth_upper,
+          number_of_events,
+          rhs_alg_id,
+          atol_np,
+          rel_tol,
+          inputs_length,
+          solver_opts,
+          setup_opts
+        )
+      )
+    );
+  }
+
+  return new IDAKLUSolverGroup(
+    std::move(solvers), number_of_states, number_of_parameters);
+}
+
 PYBIND11_MAKE_OPAQUE(std::vector<np_array>);
 PYBIND11_MAKE_OPAQUE(std::vector<np_array_realtype>);
 PYBIND11_MAKE_OPAQUE(std::vector<Solution>);
@@ -48,7 +141,7 @@ PYBIND11_MODULE(idaklu, m)
     py::arg("logger") = py::none(),
     py::return_value_policy::take_ownership);
 
-  m.def("create_casadi_solver_group", &create_idaklu_solver_group<CasadiFunctions>,
+  m.def("create_casadi_solver_group", &create_casadi_solver_group,
     "Create a group of casadi idaklu solver objects",
     py::arg("number_of_states"),
     py::arg("number_of_parameters"),

--- a/src/pybammsolvers/idaklu_source/Expressions/Casadi/CasadiFunctions.cpp
+++ b/src/pybammsolvers/idaklu_source/Expressions/Casadi/CasadiFunctions.cpp
@@ -1,9 +1,69 @@
 #include "CasadiFunctions.hpp"
 #include <casadi/core/sparsity.hpp>
 
-CasadiFunction::CasadiFunction(const BaseFunctionType &f) : Expression(), m_func(f)
+namespace {
+
+casadi::Function clone_casadi_function(
+  const CasadiFunction::BaseFunctionType &f,
+  bool deep_copy,
+  const std::string *serialized)
 {
-  DEBUG("CasadiFunction constructor: " << m_func.name());
+  if (!deep_copy) {
+    return f;
+  }
+  if (serialized != nullptr) {
+    return CasadiFunction::BaseFunctionType::deserialize(*serialized);
+  }
+  return CasadiFunction::BaseFunctionType::deserialize(f.serialize());
+}
+
+} // namespace
+
+SerializedCasadiFunctions serialize_casadi_functions(
+  const casadi::Function &rhs_alg,
+  const casadi::Function &jac_times_cjmass,
+  const casadi::Function &jac_action,
+  const casadi::Function &mass_action,
+  const casadi::Function &sens,
+  const casadi::Function &events,
+  const std::vector<casadi::Function*>& var_fcns,
+  const std::vector<casadi::Function*>& dvar_dy_fcns,
+  const std::vector<casadi::Function*>& dvar_dp_fcns)
+{
+  SerializedCasadiFunctions serialized;
+  serialized.rhs_alg = rhs_alg.serialize();
+  serialized.jac_times_cjmass = jac_times_cjmass.serialize();
+  serialized.jac_action = jac_action.serialize();
+  serialized.mass_action = mass_action.serialize();
+  serialized.sens = sens.serialize();
+  serialized.events = events.serialize();
+
+  serialized.var_fcns.reserve(var_fcns.size());
+  for (const auto *var : var_fcns) {
+    serialized.var_fcns.push_back(var->serialize());
+  }
+
+  serialized.dvar_dy_fcns.reserve(dvar_dy_fcns.size());
+  for (const auto *var : dvar_dy_fcns) {
+    serialized.dvar_dy_fcns.push_back(var->serialize());
+  }
+
+  serialized.dvar_dp_fcns.reserve(dvar_dp_fcns.size());
+  for (const auto *var : dvar_dp_fcns) {
+    serialized.dvar_dp_fcns.push_back(var->serialize());
+  }
+
+  return serialized;
+}
+
+CasadiFunction::CasadiFunction(
+  const BaseFunctionType &f,
+  bool deep_copy,
+  const std::string *serialized)
+    : Expression(),
+      m_func(clone_casadi_function(f, deep_copy, serialized))
+{
+  DEBUG("CasadiFunction constructor" << (deep_copy ? " (deep copy)" : "") << ": " << m_func.name());
 
   size_t sz_arg;
   size_t sz_res;

--- a/src/pybammsolvers/idaklu_source/Expressions/Casadi/CasadiFunctions.hpp
+++ b/src/pybammsolvers/idaklu_source/Expressions/Casadi/CasadiFunctions.hpp
@@ -5,6 +5,32 @@
 #include "../Expressions.hpp"
 #include <casadi/casadi.hpp>
 #include <casadi/core/function.hpp>
+#include <stdexcept>
+#include <string>
+
+struct SerializedCasadiFunctions {
+  std::string rhs_alg;
+  std::string jac_times_cjmass;
+  std::string jac_action;
+  std::string mass_action;
+  std::string sens;
+  std::string events;
+  std::vector<std::string> var_fcns;
+  std::vector<std::string> dvar_dy_fcns;
+  std::vector<std::string> dvar_dp_fcns;
+};
+
+SerializedCasadiFunctions serialize_casadi_functions(
+  const casadi::Function &rhs_alg,
+  const casadi::Function &jac_times_cjmass,
+  const casadi::Function &jac_action,
+  const casadi::Function &mass_action,
+  const casadi::Function &sens,
+  const casadi::Function &events,
+  const std::vector<casadi::Function*>& var_fcns,
+  const std::vector<casadi::Function*>& dvar_dy_fcns,
+  const std::vector<casadi::Function*>& dvar_dp_fcns
+);
 
 /**
  * @brief Class for handling individual casadi functions
@@ -17,8 +43,15 @@ public:
 
   /**
    * @brief Constructor
+   * @param f The CasADi function to wrap
+   * @param deep_copy If true, creates an independent copy via serialize/deserialize
+   *                  to avoid thread-unsafe shared state in parallel execution
    */
-  explicit CasadiFunction(const BaseFunctionType &f);
+  explicit CasadiFunction(
+    const BaseFunctionType &f,
+    bool deep_copy = false,
+    const std::string *serialized = nullptr
+  );
 
   // Method overrides
   void operator()() override;
@@ -74,14 +107,33 @@ public:
     const std::vector<BaseFunctionType*>& var_fcns,
     const std::vector<BaseFunctionType*>& dvar_dy_fcns,
     const std::vector<BaseFunctionType*>& dvar_dp_fcns,
-    const SetupOptions& setup_opts
+    const SetupOptions& setup_opts,
+    const SerializedCasadiFunctions *serialized_fcns = nullptr
   ) :
-    rhs_alg_casadi(rhs_alg),
-    jac_times_cjmass_casadi(jac_times_cjmass),
-    jac_action_casadi(jac_action),
-    mass_action_casadi(mass_action),
-    sens_casadi(sens),
-    events_casadi(events),
+    rhs_alg_casadi(
+      rhs_alg,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->rhs_alg : nullptr),
+    jac_times_cjmass_casadi(
+      jac_times_cjmass,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->jac_times_cjmass : nullptr),
+    jac_action_casadi(
+      jac_action,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->jac_action : nullptr),
+    mass_action_casadi(
+      mass_action,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->mass_action : nullptr),
+    sens_casadi(
+      sens,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->sens : nullptr),
+    events_casadi(
+      events,
+      setup_opts.num_solvers > 1,
+      serialized_fcns != nullptr ? &serialized_fcns->events : nullptr),
     ExpressionSet<CasadiFunction>(
       static_cast<Expression*>(&rhs_alg_casadi),
       static_cast<Expression*>(&jac_times_cjmass_casadi),
@@ -100,18 +152,40 @@ public:
   {
     // convert BaseFunctionType list to CasadiFunction list
     // NOTE: You must allocate ALL std::vector elements before taking references
-    for (auto& var : var_fcns)
-      var_fcns_casadi.push_back(CasadiFunction(*var));
+    const bool deep_copy = setup_opts.num_solvers > 1;
+    if (serialized_fcns != nullptr) {
+      if (serialized_fcns->var_fcns.size() != var_fcns.size()
+          || serialized_fcns->dvar_dy_fcns.size() != dvar_dy_fcns.size()
+          || serialized_fcns->dvar_dp_fcns.size() != dvar_dp_fcns.size()) {
+        throw std::invalid_argument("Serialized CasADi function cache has mismatched sizes");
+      }
+    }
+
+    var_fcns_casadi.reserve(var_fcns.size());
+    dvar_dy_fcns_casadi.reserve(dvar_dy_fcns.size());
+    dvar_dp_fcns_casadi.reserve(dvar_dp_fcns.size());
+
+    for (size_t k = 0; k < var_fcns.size(); k++) {
+      const std::string *serialized =
+        serialized_fcns != nullptr ? &serialized_fcns->var_fcns[k] : nullptr;
+      var_fcns_casadi.push_back(CasadiFunction(*var_fcns[k], deep_copy, serialized));
+    }
     for (int k = 0; k < var_fcns_casadi.size(); k++)
       ExpressionSet::var_fcns.push_back(&this->var_fcns_casadi[k]);
 
-    for (auto& var : dvar_dy_fcns)
-      dvar_dy_fcns_casadi.push_back(CasadiFunction(*var));
+    for (size_t k = 0; k < dvar_dy_fcns.size(); k++) {
+      const std::string *serialized =
+        serialized_fcns != nullptr ? &serialized_fcns->dvar_dy_fcns[k] : nullptr;
+      dvar_dy_fcns_casadi.push_back(CasadiFunction(*dvar_dy_fcns[k], deep_copy, serialized));
+    }
     for (int k = 0; k < dvar_dy_fcns_casadi.size(); k++)
       this->dvar_dy_fcns.push_back(&this->dvar_dy_fcns_casadi[k]);
 
-    for (auto& var : dvar_dp_fcns)
-      dvar_dp_fcns_casadi.push_back(CasadiFunction(*var));
+    for (size_t k = 0; k < dvar_dp_fcns.size(); k++) {
+      const std::string *serialized =
+        serialized_fcns != nullptr ? &serialized_fcns->dvar_dp_fcns[k] : nullptr;
+      dvar_dp_fcns_casadi.push_back(CasadiFunction(*dvar_dp_fcns[k], deep_copy, serialized));
+    }
     for (int k = 0; k < dvar_dp_fcns_casadi.size(); k++)
       this->dvar_dp_fcns.push_back(&this->dvar_dp_fcns_casadi[k]);
 

--- a/src/pybammsolvers/idaklu_source/idaklu_solver.hpp
+++ b/src/pybammsolvers/idaklu_source/idaklu_solver.hpp
@@ -189,7 +189,6 @@ IDAKLUSolverGroup *create_idaklu_solver_group(
   auto setup_opts = SetupOptions(py_opts);
   auto solver_opts = SolverOptions(py_opts);
 
-
   std::vector<std::unique_ptr<IDAKLUSolver>> solvers;
   for (int i = 0; i < setup_opts.num_solvers; i++) {
     // Note: we can't copy an ExprSet as it contains raw pointers to the functions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,28 @@ def exponential_decay_model():
 
 @pytest.fixture(scope="function")
 def exponential_decay_solver(idaklu_module, exponential_decay_model):
+    return make_exponential_decay_solver(
+        idaklu_module,
+        exponential_decay_model,
+        num_threads=1,
+        num_solvers=1,
+        decay_constants=[exponential_decay_model["k"]],
+    )
+
+
+@pytest.fixture(scope="session")
+def exponential_decay_solver_factory():
+    return make_exponential_decay_solver
+
+
+def make_exponential_decay_solver(
+    idaklu_module,
+    exponential_decay_model,
+    *,
+    num_threads,
+    num_solvers,
+    decay_constants,
+):
     """
     Fixture providing a configured solver for exponential decay model.
 
@@ -84,7 +106,7 @@ def exponential_decay_solver(idaklu_module, exponential_decay_model):
     casadi = pytest.importorskip("casadi")
 
     # Model parameters
-    k = exponential_decay_model["k"]
+    decay_constants = np.asarray(decay_constants, dtype=np.float64)
     y0 = exponential_decay_model["y0"]
 
     # Problem dimensions
@@ -190,8 +212,8 @@ def exponential_decay_solver(idaklu_module, exponential_decay_model):
         "preconditioner": "none",
         "precon_half_bandwidth": 5,
         "precon_half_bandwidth_keep": 5,
-        "num_threads": 1,
-        "num_solvers": 1,
+        "num_threads": num_threads,
+        "num_solvers": num_solvers,
         "linear_solver": "SUNLinSol_KLU",
         "linsol_max_iterations": 5,
         # SolverOptions
@@ -258,18 +280,19 @@ def exponential_decay_solver(idaklu_module, exponential_decay_model):
     # When n_sensitivity_params = 0: n_coeffs = n_states
     # When n_sensitivity_params > 0: [state_0, d(state_0)/dp_0, d(state_0)/dp_1, ...]
     n_coeffs = n_states * (1 + n_sensitivity_params)
-    y0_2d = np.zeros((1, n_coeffs), dtype=np.float64)
-    y0_2d[0, 0] = y0  # state value
+    y0_2d = np.zeros((len(decay_constants), n_coeffs), dtype=np.float64)
+    y0_2d[:, 0] = y0  # state value
 
-    yp0_2d = np.zeros((1, n_coeffs), dtype=np.float64)
-    yp0_2d[0, 0] = -k * y0  # state derivative
+    yp0_2d = np.zeros((len(decay_constants), n_coeffs), dtype=np.float64)
+    yp0_2d[:, 0] = -decay_constants * y0  # state derivative
 
-    inputs_2d = np.array([[k]], dtype=np.float64)
+    inputs_2d = decay_constants[:, np.newaxis]
 
     return {
         "solver": solver,
         "y0": y0_2d,
         "yp0": yp0_2d,
         "inputs": inputs_2d,
+        "decay_constants": decay_constants,
         "model": exponential_decay_model,
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -199,3 +199,36 @@ class TestExponentialDecaySolver:
         n_times = len(sol.t)
         assert len(sol.y) == n_times
         assert len(sol.yp) == 0  # hermite_interpolation == False
+
+    def test_parallel_solver_group_uses_multiple_solvers(
+        self, idaklu_module, exponential_decay_model, exponential_decay_solver_factory
+    ):
+        """
+        Verify the multi-solver OpenMP path returns stable, per-group solutions.
+
+        This forces num_solvers > 1 so CasADi functions are deep-copied in the
+        same parallel configuration that previously shared internal state.
+        """
+        decay_constants = np.array([0.5, 1.0], dtype=np.float64)
+        solver_data = exponential_decay_solver_factory(
+            idaklu_module,
+            exponential_decay_model,
+            num_threads=2,
+            num_solvers=2,
+            decay_constants=decay_constants,
+        )
+
+        solver = solver_data["solver"]
+        y0 = solver_data["y0"]
+        yp0 = solver_data["yp0"]
+        inputs = solver_data["inputs"]
+        t_eval = solver_data["model"]["t_eval"]
+        model_y0 = solver_data["model"]["y0"]
+
+        for _ in range(3):
+            solutions = solver.solve(t_eval, t_eval, y0, yp0, inputs)
+            assert len(solutions) == len(decay_constants)
+
+            for idx, sol in enumerate(solutions):
+                expected = model_y0 * np.exp(-decay_constants[idx] * sol.t)
+                np.testing.assert_allclose(sol.y, expected, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
casadi::Function is a SharedObject where copy construction only increments a reference count, sharing the same FunctionInternal (including memory pools). When multiple solvers run in parallel via OpenMP, they race on internal state.

Use serialize/deserialize to create fully independent FunctionInternal instances, each with its own memory pool. This eliminates the race condition that caused "invalid vector subscript" crashes on Windows.