### PR TITLE
ci: fix Windows wheel build (release crash + speed regression)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,28 +41,19 @@ jobs:
           cd vcpkg
           .\bootstrap-vcpkg.bat
 
-      # Propagate GitHub Actions cache env vars so vcpkg's `x-gha` binary
-      # source can read/write cached binaries. Disabled on release events to
-      # prevent cache poisoning attacks.
-      - name: Export GitHub Actions cache env
-        if: ${{ github.event_name != 'release' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Build wheels on Windows
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:
+          # No VCPKG_BINARY_SOURCES: keep vcpkg's default local cache
+          # (%LOCALAPPDATA%\vcpkg\archives) so the per-wheel CMake configures
+          # within this job share built ports instead of rebuilding from
+          # source for each Python version.
           CIBW_ENVIRONMENT: >
             VCPKG_ROOT_DIR=C:\vcpkg
             VCPKG_DEFAULT_TRIPLET=x64-windows-static-md
             VCPKG_FEATURE_FLAGS=manifests,registries
-            VCPKG_BINARY_SOURCES=${{ github.event_name == 'release' && '"clear"' || '"clear;x-gha,readwrite"' }}
             CMAKE_GENERATOR="Visual Studio 17 2022"
             CMAKE_GENERATOR_PLATFORM=x64
-          CIBW_ENVIRONMENT_PASS_WINDOWS: "ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN"
           CIBW_ARCHS: AMD64
           CIBW_BEFORE_BUILD: python -m pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair --add-path C:/Windows/System32 -w {dest_dir} {wheel}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -59,7 +59,7 @@ jobs:
             VCPKG_ROOT_DIR=C:\vcpkg
             VCPKG_DEFAULT_TRIPLET=x64-windows-static-md
             VCPKG_FEATURE_FLAGS=manifests,registries
-            VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"
+            VCPKG_BINARY_SOURCES=${{ github.event_name == 'release' && '"clear"' || '"clear;x-gha,readwrite"' }}
             CMAKE_GENERATOR="Visual Studio 17 2022"
             CMAKE_GENERATOR_PLATFORM=x64
           CIBW_ENVIRONMENT_PASS_WINDOWS: "ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN"


### PR DESCRIPTION
## Summary
Two-in-one fix for the Windows wheel job, both stemming from the `VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"` line added in #105.

### 1. v0.8.2 release build failure
Windows job aborted with:
```
error: The GHA binary source requires the ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL environment variables to be set.
-- Running vcpkg install - failed
```
The `Export GitHub Actions cache env` step is gated on `github.event_name != 'release'` (cache-poisoning guard added in #106), so release runs got no `ACTIONS_*` env vars while vcpkg still requested `x-gha`.

Failing run: https://github.com/pybamm-team/pybammsolvers/actions/runs/26576028362/job/78295452291

### 2. ~3x slower Windows builds since #105
Pre-#105 the Windows job ran ~25m. Post-#105 it runs ~78m. The `Build wheels on Windows` step logs five separate `Running vcpkg install` invocations (one per Python wheel cp310–cp314); each rebuilds CasADi + SUNDIALS from source for ~14m.

Pre-#105 the same five invocations existed, but only the first did real work — the next four finished in ~12s each because vcpkg's default local binary cache (`%LOCALAPPDATA%\vcpkg\archives`) was hit.

Two things went wrong in #105:
- The `clear;` token in `VCPKG_BINARY_SOURCES` purges the default local cache.
- The replacement `x-gha,readwrite` never actually caches. `actions/github-script@v7` no longer sees `process.env.ACTIONS_CACHE_URL` (GitHub migrated the Actions cache service to v2 / `ACTIONS_RESULTS_URL` in late 2025), so the export sets the var to an empty string. vcpkg duly reports `Restored 0 package(s) ... Stored binaries in 0 destinations`.

Reference: https://github.com/pybamm-team/pybammsolvers/actions/runs/26538023951/job/78184270155 (PR run, x-gha "enabled", still 80m).

### Change
Drop `VCPKG_BINARY_SOURCES`, the `Export GitHub Actions cache env` step, and the now-unused `CIBW_ENVIRONMENT_PASS_WINDOWS`. vcpkg falls back to its default local cache, so the first wheel populates it and the rest are no-ops — matching pre-#105 behaviour.

Cross-run caching (via `actions/cache` on `%LOCALAPPDATA%\vcpkg\archives`, or a working x-gha config against the current cache service) can be added in a follow-up.

## Test plan
- [ ] Confirm PR CI Windows job time drops back to ~25m.
- [ ] After merge, re-tag v0.8.2 (release already deleted) and confirm the release run's Windows job completes.
